### PR TITLE
fix broken install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ upgrade your python and npm.
  2.- Execute the following commands on Cloud 9 (you can just copy and paste)
 ```
 export VERSION=1.0.3
-wget https://github.com/aws-samples/ec2-spot-placement-score-tracker/archive/refs/tags/v$VERSION.tar.gz -O ec2-spot-placement-score-tracker-v$VERSION.tar.gz
+wget https://github.com/aws-solutions-library-samples/guidance-for-ec2-spot-placement-score-tracker/archive/refs/tags/v$VERSION.tar.gz -O ec2-spot-placement-score-tracker-v$VERSION.tar.gz
 tar xzvf ec2-spot-placement-score-tracker-v$VERSION.tar.gz
-cd $HOME/environment/ec2-spot-placement-score-tracker-$VERSION
+cd $HOME/environment/guidance-for-ec2-spot-placement-score-tracker-$VERSION
 ```
 
 #### Configuring the Cloud9 Setup before deployment


### PR DESCRIPTION
Currently the install has the user run in Cloud9 this command:

```
export VERSION=1.0.3
wget https://github.com/aws-samples/ec2-spot-placement-score-tracker/archive/refs/tags/v$VERSION.tar.gz -O ec2-spot-placement-score-tracker-v$VERSION.tar.gz
tar xzvf ec2-spot-placement-score-tracker-v$VERSION.tar.gz
cd $HOME/environment/ec2-spot-placement-score-tracker-$VERSION
```
But the repo has changed. While the wget does redirect, and we rename the file upon download with wget -O, the extracted directory is not correct as it is based on the actual directory structure so the last step breaks. The change in this PR updates the URL with the current one and changes the final CD command to point to the actual directory that gets extracted: $HOME/environment/guidance-for-ec2-spot-placement-score-tracker-$VERSION


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
